### PR TITLE
feat(home): surface vagrant-story with arcade menu and CRT power-on

### DIFF
--- a/src/pages/home/crt.css
+++ b/src/pages/home/crt.css
@@ -227,8 +227,189 @@
     inset 0 0 30px rgba(0, 0, 0, 0.3);
 }
 
+/* The tube wraps everything inside the screen so the power-on animation
+   can sweep the scanlines, curvature, static and content together. */
+.crt-tube {
+  transform-style: preserve-3d;
+  animation:
+    crt-power-on-shape 1s cubic-bezier(0.2, 0.85, 0.25, 1) both,
+    crt-power-on-brightness 1s cubic-bezier(0.2, 0.85, 0.25, 1) both;
+}
+
+/* Pure-white flash overlay sharing the tube's clip-path keyframes so
+   the center point and horizontal line read as phosphor-bright white,
+   then fades out as the content is revealed behind it. */
+.crt-screen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: white;
+  z-index: 27;
+  pointer-events: none;
+  animation:
+    crt-power-on-shape 1s cubic-bezier(0.2, 0.85, 0.25, 1) both,
+    crt-power-on-flash 1s cubic-bezier(0.2, 0.85, 0.25, 1) both;
+}
+
 /* Inner content gets a slight forward push — center feels closer */
-.crt-screen > .crt-content {
+.crt-content {
   transform: translateZ(20px) scale(0.97);
   transform-style: preserve-3d;
+}
+
+@keyframes crt-power-on-shape {
+  /* 1. center dot */
+  0% {
+    clip-path: inset(49.6% 49.6% 49.6% 49.6%);
+  }
+  14% {
+    clip-path: inset(49.6% 49.6% 49.6% 49.6%);
+  }
+  /* 2. expand uniformly left+right into a horizontal line */
+  32% {
+    clip-path: inset(49.4% 0 49.4% 0);
+  }
+  42% {
+    clip-path: inset(48.5% 0 48.5% 0);
+  }
+  /* 3. expand uniformly up+down to fill */
+  80% {
+    clip-path: inset(0 0 0 0);
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+@keyframes crt-power-on-brightness {
+  0%,
+  42% {
+    filter: brightness(3) saturate(0.2);
+  }
+  80% {
+    filter: brightness(1.4) saturate(0.85);
+  }
+  100% {
+    filter: brightness(1) saturate(1);
+  }
+}
+
+@keyframes crt-power-on-flash {
+  0%,
+  28% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+  75% {
+    opacity: 0.08;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Arcade cabinet menu */
+.crt-menu {
+  list-style: none;
+  padding: 0;
+  margin: 2rem auto 0;
+  min-width: min(20rem, 90%);
+  max-width: 26rem;
+  text-align: left;
+}
+
+.crt-menu li + li {
+  margin-top: 0.25rem;
+}
+
+.crt-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.3rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-decoration: none;
+  color: var(--primary);
+  text-shadow:
+    0 0 6px color-mix(in oklch, var(--primary) 55%, transparent),
+    0 0 14px color-mix(in oklch, var(--primary) 25%, transparent);
+  transition:
+    text-shadow 140ms ease-out,
+    background-color 140ms ease-out;
+}
+
+.crt-menu-row--active:hover,
+.crt-menu-row--active:focus-visible {
+  outline: none;
+  background-color: color-mix(in oklch, var(--primary) 12%, transparent);
+  text-shadow:
+    0 0 10px var(--primary),
+    0 0 24px color-mix(in oklch, var(--primary) 70%, transparent),
+    0 0 48px color-mix(in oklch, var(--primary) 40%, transparent);
+}
+
+/* Shift only the cursor glyph — never the row itself, or hover drops
+   out from under the mouse and flickers. */
+.crt-menu-row--active .crt-menu-cursor {
+  transition: transform 140ms ease-out;
+}
+
+.crt-menu-row--active:hover .crt-menu-cursor,
+.crt-menu-row--active:focus-visible .crt-menu-cursor {
+  transform: translateX(3px);
+}
+
+.crt-menu-row--disabled {
+  color: color-mix(in oklch, var(--muted-foreground) 75%, transparent);
+  text-shadow: none;
+  cursor: default;
+}
+
+.crt-menu-cursor {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 1ch;
+}
+
+.crt-menu-row--active .crt-menu-cursor {
+  animation: crt-cursor-blink 1.1s steps(2, jump-none) infinite;
+}
+
+.crt-menu-dots {
+  flex: 1;
+  height: 0.55em;
+  border-bottom: 2px dotted currentColor;
+  min-width: 1.5em;
+  opacity: 0.45;
+}
+
+@keyframes crt-cursor-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+/* Respect users who've asked for less motion — kill the power-on sweep,
+   flash overlay, flicker, glow pulse, and cursor blink. Keep the final
+   rendered frame. */
+@media (prefers-reduced-motion: reduce) {
+  .crt-tube,
+  .crt-screen::after,
+  .crt-glow,
+  .crt-static,
+  .crt-menu-row--active .crt-menu-cursor {
+    animation: none;
+  }
+  .crt-screen::after {
+    display: none;
+  }
 }

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -1,20 +1,76 @@
+import { useRef, type KeyboardEvent } from "react"
 import "./crt.css"
 
 export function HomePage() {
+  const menuRef = useRef<HTMLUListElement>(null)
+
+  function handleMenuKeyDown(event: KeyboardEvent<HTMLUListElement>) {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return
+    const links = menuRef.current?.querySelectorAll<HTMLAnchorElement>(
+      "a.crt-menu-row--active"
+    )
+    if (!links || links.length === 0) return
+    event.preventDefault()
+    const items = Array.from(links)
+    const currentIndex = items.indexOf(
+      document.activeElement as HTMLAnchorElement
+    )
+    const delta = event.key === "ArrowDown" ? 1 : -1
+    const nextIndex =
+      currentIndex === -1
+        ? 0
+        : (currentIndex + delta + items.length) % items.length
+    items[nextIndex]?.focus()
+  }
+
   return (
     <div className="flex flex-1 p-4">
       <div className="crt-screen border-border/40 relative flex flex-1 items-center justify-center overflow-hidden rounded-2xl border bg-black/80">
-        <div className="crt-scanlines pointer-events-none absolute inset-0" />
-        <div className="crt-curvature pointer-events-none absolute inset-0" />
-        <div className="crt-static pointer-events-none absolute inset-0" />
-        <div className="crt-content relative text-center">
-          <h1 className="crt-glow font-pixel text-6xl tracking-wide sm:text-8xl">
-            CriticalBit
-          </h1>
-          <p className="text-muted-foreground mt-4 text-lg">
-            Community gaming tools for the games you love.
-          </p>
-          <p className="text-muted-foreground mt-2 text-sm">Coming soon.</p>
+        <div className="crt-tube absolute inset-0 flex items-center justify-center">
+          <div className="crt-scanlines pointer-events-none absolute inset-0" />
+          <div className="crt-curvature pointer-events-none absolute inset-0" />
+          <div className="crt-static pointer-events-none absolute inset-0" />
+          <div className="crt-content relative text-center">
+            <h1 className="crt-glow font-pixel text-6xl tracking-wide sm:text-8xl">
+              <span className="text-white">Critical</span>
+              <span>Bit</span>
+            </h1>
+            <p className="text-muted-foreground mt-4 text-lg">
+              Community gaming tools for the games you love.
+            </p>
+            <ul
+              ref={menuRef}
+              onKeyDown={handleMenuKeyDown}
+              className="crt-menu font-pixel mt-8"
+            >
+              <li>
+                <a
+                  className="crt-menu-row crt-menu-row--active"
+                  href="https://vagrant-story.criticalbit.gg"
+                >
+                  <span className="crt-menu-cursor" aria-hidden>
+                    ▸
+                  </span>
+                  <span>VAGRANT STORY</span>
+                  <span className="crt-menu-dots" aria-hidden />
+                  <span>[PLAY]</span>
+                </a>
+              </li>
+              <li>
+                <div
+                  className="crt-menu-row crt-menu-row--disabled"
+                  aria-disabled="true"
+                >
+                  <span className="crt-menu-cursor" aria-hidden>
+                    {" "}
+                  </span>
+                  <span>COMING SOON</span>
+                  <span className="crt-menu-dots" aria-hidden />
+                  <span>[----]</span>
+                </div>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Splits the `CriticalBit` title so `Critical` is white and `Bit` keeps the primary-color phosphor glow, then drops the "Coming soon." copy in favor of an arcade-cabinet menu under the tagline.
- `VAGRANT STORY ... [PLAY]` links to `https://vagrant-story.criticalbit.gg` in the same tab (per the plan at `.claude/PLAN_surface-vagrant-story.md`), with a blinking `▸` cursor, dotted leader line, hover/focus glow + background tint, and a disabled `COMING SOON [----]` row that reserves the slot for the next project. `ArrowUp` / `ArrowDown` cycle between active rows once the menu has focus, so this scales naturally as more projects ship.
- Adds a CRT power-on sequence: clip-path animates through center dot → uniform horizontal line → uniform vertical expansion (1s total), and a white `::after` flash on `.crt-screen` shares the same shape keyframes while easing out across the second half of the animation so the discharge reads as a bright phosphor flash instead of a hard cut. `prefers-reduced-motion` disables the sweep, flash, cursor blink, glow pulse, and static flicker.

## Implementation notes
- Scanlines, curvature, static, and content are now wrapped in a `.crt-tube` so the clip-path sweep can mask them all together; the 3D translate moved from `.crt-screen > .crt-content` onto `.crt-content` directly and `.crt-tube` carries `transform-style: preserve-3d` so the outer `perspective: 1200px` still reaches the content.
- The row hover transform lives on the `▸` cursor glyph only — shifting the row itself caused a hover flicker loop because the mouse dropped out from under `translateX`.
- `home-page.test.tsx` still passes unchanged (the split spans concatenate to `CriticalBit` via `textContent`).

## Test plan
- [ ] `https://vagrant-story.criticalbit.gg` opens in the same tab on click
- [ ] Tab → Enter activates the link; Arrow keys cycle (no-op with one active row, but wiring is in place)
- [ ] Power-on plays on load: center dot → horizontal line → vertical expand, with the white flash easing out past the halfway mark
- [ ] Mobile layout holds (single centered CRT block, menu width capped at `26rem`)
- [ ] `prefers-reduced-motion: reduce` skips the sweep, flash, blink, pulse, and static flicker and lands on the final frame
- [ ] Glass reflection, scanlines, curvature, and static overlays still render after the power-on completes