### PR TITLE
fix(privacy): accurate PostHog disclosure; add analytics to "what we collect"

### DIFF
--- a/src/pages/privacy/privacy-page.tsx
+++ b/src/pages/privacy/privacy-page.tsx
@@ -28,6 +28,14 @@ export function PrivacyPage() {
         <section>
           <h2 className="mb-2 text-lg font-semibold">What we collect</h2>
           <p>
+            When you visit and use the site, we collect product analytics events
+            about page views and feature interactions, along with your IP
+            address and browser user-agent string. This helps us understand
+            usage patterns and prioritize improvements. These events are not
+            currently associated with any persistent user identifier — each site
+            visit is treated as a new anonymous session.
+          </p>
+          <p>
             When you create an account, we collect your email address. If you
             sign in with Google or Steam, we receive your profile information
             (name, avatar) from those services.
@@ -107,9 +115,12 @@ export function PrivacyPage() {
               (password resets).
             </li>
             <li>
-              <strong>PostHog</strong> — for anonymous, cookie-free product
-              analytics across criticalbit tools. No personal identifiers or
-              cross-session tracking. Subject to{" "}
+              <strong>PostHog</strong> — for product analytics across
+              criticalbit tools. PostHog receives page views, interaction
+              events, your IP address, and browser user-agent string. It is
+              currently configured without cross-session tracking cookies; each
+              site visit is treated as a new anonymous session with no
+              persistent user identifier. Subject to{" "}
               <a
                 href="https://posthog.com/privacy"
                 className="text-primary underline"


### PR DESCRIPTION
## Summary
Two related accuracy corrections to the privacy policy PostHog language, following review of PR #11.

## The problem

The PostHog entry claimed:
> "for anonymous, cookie-free product analytics across criticalbit tools. **No personal identifiers or cross-session tracking.**"

The \"no personal identifiers\" part is **factually wrong** even in the current memory-only configuration. PostHog always receives:
- Client IP address (resolved server-side)
- Browser user-agent string
- Page URL with query strings

Under GDPR, IP addresses are personal identifiers — established by the 2016 CJEU Breyer case ([C-582/14](https://curia.europa.eu/juris/liste.jsf?num=C-582/14)) and reinforced by subsequent DPA guidance. Claiming \"no personal identifiers\" while PostHog receives IPs is misleading and the kind of statement a regulator could flag.

Separately, the \"What we collect\" section (which I updated in PR #11) only mentioned error diagnostics and account creation — it never disclosed the general product analytics captured on every page visit. That was a disclosure gap.

## Changes

**1. New paragraph in \"What we collect\"** covering product analytics:
- Page views and interaction events
- IP address and user-agent
- Explicit statement that no persistent user identifier is currently attached (i.e., cross-session tracking is not in effect)

**2. PostHog entry in \"Third-party services\" rewritten**:
- Drops the \"anonymous, cookie-free\" opening and the \"no personal identifiers\" claim
- Explicitly lists what PostHog receives: page views, events, IP, user-agent
- Keeps the accurate point that cross-session tracking cookies are not currently configured

## What's deliberately NOT changed

**The Cookies section is untouched.** Its claim that PostHog is in \"cookie-free mode and does not set any cookies\" is accurate — PostHog is currently \`persistence: \"memory\"\`. This will need to change as part of Phase 3 (consent banner + cross-subdomain cookies), but today the statement is correct.

## Test plan
- [x] \`pnpm lint\` passes (0 errors, 2 pre-existing warnings)
- [x] \`pnpm test:run\` passes (1/1)
- [x] \`pnpm build\` passes
- [ ] Post-merge: spot-check \`criticalbit.gg/privacy\` to confirm the updated wording renders correctly

## Related
Supersedes the stale language left in place after #11. Both accuracy issues should have been caught in that PR's review — flagged retroactively by the user after seeing the live page.