### PR TITLE
docs(privacy): expose ISO policy version alongside human-readable date

### DIFF
--- a/src/pages/privacy/privacy-page.tsx
+++ b/src/pages/privacy/privacy-page.tsx
@@ -2,8 +2,13 @@ export function PrivacyPage() {
   return (
     <div className="mx-auto max-w-2xl px-4 py-12">
       <h1 className="font-pixel mb-8 text-3xl tracking-wide">Privacy Policy</h1>
+      {/*
+       * Keep the ISO date below in sync with CURRENT_POLICY_VERSION in
+       * criticalbit-auth-api app/consent/constants.py — bumping it is what
+       * triggers consent re-prompting for existing users.
+       */}
       <p className="text-muted-foreground mb-6 text-sm">
-        Last updated: April 12, 2026
+        Last updated: April 12, 2026 (version 2026-04-12)
       </p>
 
       <div className="prose prose-sm dark:prose-invert max-w-none space-y-6 text-sm leading-relaxed">


### PR DESCRIPTION
## Summary
- Append \`(version 2026-04-12)\` after the existing "Last updated: April 12, 2026" line so the policy carries a machine-readable version string visible to users
- Inline comment pointing maintainers at \`CURRENT_POLICY_VERSION\` in \`criticalbit-auth-api/app/consent/constants.py\` so bumps happen in both places

This is a prerequisite for Phase 3 of the consent rollout. The auth-api consent endpoints (shipped in criticalbit-auth-api#19) stamp every consent row with \`CURRENT_POLICY_VERSION\`; the \`is_stale\` flag returned to frontends compares stored version against that constant. Keeping the user-facing policy version and the backend constant in lockstep is what makes re-prompting after a policy update work correctly.

No behavior change — this is a copy/docs-only update.

## Test plan
- [x] \`pnpm lint\` clean (2 pre-existing warnings unrelated to this change)
- [x] \`pnpm format:check\` clean
- [x] Pre-commit hook (lint + build) passed locally
- [ ] Visual check: "Last updated: April 12, 2026 (version 2026-04-12)" renders on /privacy