### PR TITLE
refactor: move error and not-found components to router defaults

### DIFF
--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { logger } from "@/lib/logger"
 import { captureException } from "@/lib/sentry"
 
-export function RootErrorComponent({ error, reset }: ErrorComponentProps) {
+export function ErrorBoundary({ error, reset }: ErrorComponentProps) {
   logger.error("Uncaught error in route component", {
     message: error.message,
     stack: error.stack,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import { createRoot } from "react-dom/client"
 import { reactErrorHandler } from "@sentry/react"
 // @ts-expect-error -- fontsource CSS-only import, no types
 import "@fontsource-variable/geist"
+import { ErrorBoundary } from "./components/error-boundary"
+import { NotFound } from "./components/not-found"
 import { ThemeProvider } from "./components/theme-provider"
 import "./index.css"
 import { Skeleton } from "./components/ui/skeleton"
@@ -20,6 +22,8 @@ const router = createRouter({
   context: { queryClient, auth: undefined! },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
+  defaultNotFoundComponent: NotFound,
+  defaultErrorComponent: ErrorBoundary,
 })
 
 initSentry(router)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,10 +2,8 @@ import { lazy, Suspense } from "react"
 import { QueryClient } from "@tanstack/react-query"
 import { createRootRouteWithContext, Outlet } from "@tanstack/react-router"
 import { Toaster } from "sonner"
-import { RootErrorComponent } from "@/components/error-boundary"
 import { Footer } from "@/components/footer"
 import { Navbar } from "@/components/navbar"
-import { NotFound } from "@/components/not-found"
 
 const TanStackRouterDevtools = import.meta.env.PROD
   ? () => null
@@ -32,8 +30,6 @@ interface RouterContext {
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
-  notFoundComponent: NotFound,
-  errorComponent: RootErrorComponent,
 })
 
 function RootComponent() {


### PR DESCRIPTION
## Summary
- Register the error boundary and not-found component on the router via `defaultErrorComponent` / `defaultNotFoundComponent` in `main.tsx` instead of on the root route. This lets the boundary catch errors thrown by the root route itself — the route-level prop can't, since the boundary is hosted inside the same route it's protecting.
- Rename `RootErrorComponent` → `ErrorBoundary` so the export matches the `error-boundary.tsx` filename.
- Per-route `errorComponent` / `notFoundComponent` props still work for routes that want to override.

## Test plan
- [ ] `pnpm dev` — app boots normally
- [ ] Visit a bogus path — 404 page renders
- [ ] Throw inside a route component — error page renders with working "Try again" / "Go home" buttons
- [ ] `pnpm build` and `pnpm test:run` both pass