### PR TITLE
feat(home): link The King's Gauntlet above Vagrant Story

### DIFF
--- a/src/pages/home/home-page.test.tsx
+++ b/src/pages/home/home-page.test.tsx
@@ -9,4 +9,22 @@ describe("HomePage", () => {
       /criticalbit\.gg/i
     )
   })
+
+  it("links The King's Gauntlet to the aoe2 tournament path", async () => {
+    await renderWithFileRoutes(<></>)
+    expect(
+      screen.getByRole("link", { name: /king's gauntlet/i })
+    ).toHaveAttribute("href", "https://aoe2.criticalbit.gg/kings-gauntlet")
+  })
+
+  it("orders The King's Gauntlet above Vagrant Story in the menu", async () => {
+    await renderWithFileRoutes(<></>)
+    const gauntlet = screen.getByRole("link", { name: /king's gauntlet/i })
+    const vagrant = screen.getByRole("link", { name: /vagrant story/i })
+    // bit 4 (DOCUMENT_POSITION_FOLLOWING) set => vagrant comes after gauntlet
+    expect(
+      gauntlet.compareDocumentPosition(vagrant) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
 })

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -48,6 +48,19 @@ export function HomePage() {
               <li>
                 <a
                   className="crt-menu-row crt-menu-row--active"
+                  href="https://aoe2.criticalbit.gg/kings-gauntlet"
+                >
+                  <span className="crt-menu-cursor" aria-hidden>
+                    ▸
+                  </span>
+                  <span>THE KING&apos;S GAUNTLET</span>
+                  <span className="crt-menu-dots" aria-hidden />
+                  <span>[WATCH]</span>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="crt-menu-row crt-menu-row--active"
                   href="https://vagrant-story.criticalbit.gg"
                 >
                   <span className="crt-menu-cursor" aria-hidden>


### PR DESCRIPTION
Adds a new CRT menu row linking to **The King's Gauntlet**, placed directly above Vagrant Story on the home page.

- **Label:** `THE KING'S GAUNTLET` — all-caps to match the existing `VAGRANT STORY` / `COMING SOON` rows
- **URL:** `https://aoe2.criticalbit.gg/kings-gauntlet` — path-based tournament route on the aoe2 subdomain
- **Action tag:** `[WATCH]`

Reuses the existing `crt-menu-row--active` markup, so the row inherits the phosphor glow, hover cursor shift, and arrow-key navigation with no extra wiring.

### Tests
- Asserts the link points at the King's Gauntlet URL.
- Asserts the row renders **above** Vagrant Story (`compareDocumentPosition`).

Closes #21
