### PR TITLE
fix(theme): readable light-mode primary, decoupled CRT glow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -23,8 +23,12 @@
   --card-foreground: oklch(0.22 0.02 260);
   --popover: oklch(0.99 0.005 230);
   --popover-foreground: oklch(0.22 0.02 260);
-  --primary: oklch(0.88 0.08 210);
-  --primary-foreground: oklch(0.18 0.015 270);
+  --primary: oklch(0.5 0.15 225);
+  --primary-foreground: oklch(0.98 0.005 230);
+  /* Bright icy-blue phosphor for the always-dark CRT screen (home page).
+     Kept theme-independent — the screen is bg-black in both light and dark
+     mode, so it must not follow the readable, darker light-mode --primary. */
+  --crt-primary: oklch(0.82 0.11 220);
   --secondary: oklch(0.94 0.01 230);
   --secondary-foreground: oklch(0.22 0.02 260);
   --muted: oklch(0.94 0.01 230);
@@ -35,8 +39,8 @@
   --destructive-foreground: oklch(0.58 0.22 28);
   --border: oklch(0.9 0.01 230);
   --input: oklch(0.9 0.01 230);
-  --ring: oklch(0.88 0.08 210);
-  --chart-1: oklch(0.88 0.08 210);
+  --ring: oklch(0.5 0.15 225);
+  --chart-1: oklch(0.5 0.15 225);
   --chart-2: oklch(0.75 0.17 165);
   --chart-3: oklch(0.75 0.15 75);
   --chart-4: oklch(0.6 0.2 300);

--- a/src/pages/home/crt.css
+++ b/src/pages/home/crt.css
@@ -183,12 +183,12 @@
 
 /* Layer 4: CRT phosphor glow on title */
 .crt-glow {
-  color: var(--primary);
+  color: var(--crt-primary);
   text-shadow:
-    0 0 20px var(--primary),
-    0 0 50px color-mix(in oklch, var(--primary) 70%, transparent),
-    0 0 100px color-mix(in oklch, var(--primary) 45%, transparent),
-    0 0 150px color-mix(in oklch, var(--primary) 20%, transparent);
+    0 0 20px var(--crt-primary),
+    0 0 50px color-mix(in oklch, var(--crt-primary) 70%, transparent),
+    0 0 100px color-mix(in oklch, var(--crt-primary) 45%, transparent),
+    0 0 150px color-mix(in oklch, var(--crt-primary) 20%, transparent);
   animation: crt-glow-pulse 3s ease-in-out infinite;
 }
 
@@ -205,9 +205,11 @@
 /* Icon counterpart to .crt-glow — drop-shadow reaches SVG shapes that
    text-shadow cannot. */
 .crt-glow-icon {
-  color: var(--primary);
-  filter: drop-shadow(0 0 14px var(--primary))
-    drop-shadow(0 0 36px color-mix(in oklch, var(--primary) 50%, transparent));
+  color: var(--crt-primary);
+  filter: drop-shadow(0 0 14px var(--crt-primary))
+    drop-shadow(
+      0 0 36px color-mix(in oklch, var(--crt-primary) 50%, transparent)
+    );
   animation: crt-glow-pulse 3s ease-in-out infinite;
 }
 
@@ -342,10 +344,10 @@
   font-size: 0.95rem;
   letter-spacing: 0.12em;
   text-decoration: none;
-  color: var(--primary);
+  color: var(--crt-primary);
   text-shadow:
-    0 0 6px color-mix(in oklch, var(--primary) 55%, transparent),
-    0 0 14px color-mix(in oklch, var(--primary) 25%, transparent);
+    0 0 6px color-mix(in oklch, var(--crt-primary) 55%, transparent),
+    0 0 14px color-mix(in oklch, var(--crt-primary) 25%, transparent);
   transition:
     text-shadow 140ms ease-out,
     background-color 140ms ease-out;
@@ -354,11 +356,11 @@
 .crt-menu-row--active:hover,
 .crt-menu-row--active:focus-visible {
   outline: none;
-  background-color: color-mix(in oklch, var(--primary) 12%, transparent);
+  background-color: color-mix(in oklch, var(--crt-primary) 12%, transparent);
   text-shadow:
-    0 0 10px var(--primary),
-    0 0 24px color-mix(in oklch, var(--primary) 70%, transparent),
-    0 0 48px color-mix(in oklch, var(--primary) 40%, transparent);
+    0 0 10px var(--crt-primary),
+    0 0 24px color-mix(in oklch, var(--crt-primary) 70%, transparent),
+    0 0 48px color-mix(in oklch, var(--crt-primary) 40%, transparent);
 }
 
 /* Shift only the cursor glyph — never the row itself, or hover drops


### PR DESCRIPTION
The light-mode `--primary` ("icy blue", `oklch(0.88 0.08 210)`) was unreadable as text — about **1.29:1** against the light background, far below the WCAG AA 4.5:1 floor. It affected every `text-primary` surface: privacy/terms links, the `.gg`/`BIT` wordmark, the 404 & Error headings, the brand icon, and the `link` button variant.

### Root cause
`--primary` served two conflicting roles:
1. The always-bright phosphor glow on the home page's CRT screen, which is `bg-black` in **both** themes.
2. The semantic UI color, which must be readable on **light** surfaces in light mode.

Darkening it for (2) would have muddied the signature CRT glow for (1).

### Changes
- **Decouple the CRT:** new theme-independent `--crt-primary: oklch(0.82 0.11 220)`. All `crt.css` glow rules now reference it, so the home page glows identically in light and dark mode.
- **Retune light-mode `--primary`** → `oklch(0.5 0.15 225)` (`#0071a2`) — same icy-blue hue family, now **4.95:1** on the background. Mirrored to `--ring` and `--chart-1`.
- **Flip light-mode `--primary-foreground`** to near-white so `bg-primary` buttons, avatars, and text selection stay legible (white-on-primary **5.09:1**).

Contrast verified numerically (oklch → sRGB → WCAG) and visually in both themes; the CRT glow is unchanged.

Closes #25
