### PR TITLE
feat(home): feature The King's Gauntlet with Hera host credit

### DIFF
--- a/src/pages/home/crt.css
+++ b/src/pages/home/crt.css
@@ -409,6 +409,62 @@
   }
 }
 
+/* Featured event — a phosphor frame plus a slower, brighter pulse lifts
+   the marquee event above the peer rows. Switching to a column stacks the
+   "hosted by" credit beneath the label line. */
+.crt-menu-row--featured {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.4rem;
+  padding: 0.7rem 0.85rem;
+  font-size: 1.1rem;
+  border: 1px solid color-mix(in oklch, var(--crt-primary) 50%, transparent);
+  border-radius: 0.45rem;
+  background-color: color-mix(in oklch, var(--crt-primary) 7%, transparent);
+  box-shadow:
+    0 0 14px color-mix(in oklch, var(--crt-primary) 32%, transparent),
+    0 0 32px color-mix(in oklch, var(--crt-primary) 15%, transparent),
+    inset 0 0 18px color-mix(in oklch, var(--crt-primary) 8%, transparent);
+  animation: crt-featured-pulse 4s ease-in-out infinite;
+}
+
+/* Rebuild the horizontal label row inside the frame — the parent's column
+   direction would otherwise stack the cursor, title, dots and tag. */
+.crt-menu-row__line {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* Host credit — quieter and smaller than the label, uppercased to match
+   the terminal voice while the markup keeps its readable casing. */
+.crt-menu-subtitle {
+  text-align: center;
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  text-shadow: 0 0 6px color-mix(in oklch, var(--crt-primary) 45%, transparent);
+}
+
+@keyframes crt-featured-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 12px color-mix(in oklch, var(--crt-primary) 28%, transparent),
+      0 0 26px color-mix(in oklch, var(--crt-primary) 13%, transparent),
+      inset 0 0 16px color-mix(in oklch, var(--crt-primary) 7%, transparent);
+    border-color: color-mix(in oklch, var(--crt-primary) 45%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 20px color-mix(in oklch, var(--crt-primary) 50%, transparent),
+      0 0 44px color-mix(in oklch, var(--crt-primary) 26%, transparent),
+      inset 0 0 24px color-mix(in oklch, var(--crt-primary) 13%, transparent);
+    border-color: color-mix(in oklch, var(--crt-primary) 75%, transparent);
+  }
+}
+
 /* Respect users who've asked for less motion — kill the power-on sweep,
    flash overlay, flicker, glow pulse, and cursor blink. Keep the final
    rendered frame. */
@@ -418,6 +474,7 @@
   .crt-glow,
   .crt-glow-icon,
   .crt-static,
+  .crt-menu-row--featured,
   .crt-menu-row--active .crt-menu-cursor {
     animation: none;
   }

--- a/src/pages/home/home-page.test.tsx
+++ b/src/pages/home/home-page.test.tsx
@@ -17,6 +17,13 @@ describe("HomePage", () => {
     ).toHaveAttribute("href", "https://aoe2.criticalbit.gg/kings-gauntlet")
   })
 
+  it("credits Hera as host of The King's Gauntlet", async () => {
+    await renderWithFileRoutes(<></>)
+    expect(
+      screen.getByRole("link", { name: /king's gauntlet/i })
+    ).toHaveTextContent(/hosted by hera/i)
+  })
+
   it("orders The King's Gauntlet above Vagrant Story in the menu", async () => {
     await renderWithFileRoutes(<></>)
     const gauntlet = screen.getByRole("link", { name: /king's gauntlet/i })

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -47,15 +47,18 @@ export function HomePage() {
             >
               <li>
                 <a
-                  className="crt-menu-row crt-menu-row--active"
+                  className="crt-menu-row crt-menu-row--active crt-menu-row--featured"
                   href="https://aoe2.criticalbit.gg/kings-gauntlet"
                 >
-                  <span className="crt-menu-cursor" aria-hidden>
-                    ▸
+                  <span className="crt-menu-row__line">
+                    <span className="crt-menu-cursor" aria-hidden>
+                      ▸
+                    </span>
+                    <span>THE KING&apos;S GAUNTLET</span>
+                    <span className="crt-menu-dots" aria-hidden />
+                    <span>[WATCH]</span>
                   </span>
-                  <span>THE KING&apos;S GAUNTLET</span>
-                  <span className="crt-menu-dots" aria-hidden />
-                  <span>[WATCH]</span>
+                  <span className="crt-menu-subtitle">Hosted by Hera</span>
                 </a>
               </li>
               <li>


### PR DESCRIPTION
## What & why

The King's Gauntlet is a major event, but in the home-page menu it sat as a visual peer to a game link and a disabled placeholder. This promotes it to a featured marquee row so it draws the eye, and credits Hera as host.

## Changes

- **Featured frame** — the event row is wrapped in a glowing phosphor frame (layered `box-shadow` bloom + tinted background) with a slower, brighter `crt-featured-pulse` so it "breathes" above the peer rows. Stays within the existing icy-blue CRT palette.
- **Bigger label** — the featured row is enlarged to `1.1rem`; its cursor, dotted leader, and `[WATCH]` tag scale with it as one unit.
- **"Hosted by Hera" credit** — centered beneath the title, smaller and dimmer, uppercased via CSS to match the terminal voice. The markup keeps readable casing, so the credit stays in the link's accessible name and reads to screen readers.
- **Motion-safe** — the new pulse joins the existing `prefers-reduced-motion` opt-out, so reduced-motion users get the static frame glow with no animation.

The base `.crt-menu-row` rules are untouched, so Vagrant Story and Coming Soon are unchanged. The featured treatment is purely additive via a `--featured` modifier plus an inner `__line` wrapper that rebuilds the horizontal row inside the frame.

## Test plan

- `pnpm test:run` — 6 passing, including a new test asserting the King's Gauntlet link credits "Hosted by Hera".
- `pnpm lint` — 0 errors (only pre-existing fast-refresh warnings in unrelated files).
- `pnpm build` — succeeds.
- Verified visually in dev (headless): the framed, enlarged event row sits above the two plain rows with the centered host credit.
