### PR TITLE
chore(home): de-feature The King's Gauntlet now the tournament has ended

### DIFF
--- a/src/pages/home/crt.css
+++ b/src/pages/home/crt.css
@@ -409,13 +409,21 @@
   }
 }
 
-/* Featured event — a phosphor frame plus a slower, brighter pulse lifts
-   the marquee event above the peer rows. Switching to a column stacks the
-   "hosted by" credit beneath the label line. */
-.crt-menu-row--featured {
+/* Stacked row — switches to a column so .crt-menu-row__line can carry the
+   horizontal label while a .crt-menu-subtitle (e.g. a host credit) sits
+   beneath it. Layout only, no frame or pulse, so a credited row still reads
+   as a peer of the plain rows. */
+.crt-menu-row--stacked {
   flex-direction: column;
   align-items: stretch;
   gap: 0.4rem;
+}
+
+/* Featured event — a phosphor frame plus a slower, brighter pulse to lift a
+   marquee event above its peers; pair with --stacked when it also needs a
+   subtitle. Currently unused (nothing is featured) — kept for reuse when the
+   next event lands. */
+.crt-menu-row--featured {
   padding: 0.7rem 0.85rem;
   font-size: 1.1rem;
   border: 1px solid color-mix(in oklch, var(--crt-primary) 50%, transparent);

--- a/src/pages/home/home-page.test.tsx
+++ b/src/pages/home/home-page.test.tsx
@@ -24,6 +24,15 @@ describe("HomePage", () => {
     ).toHaveTextContent(/hosted by hera/i)
   })
 
+  it("renders The King's Gauntlet as a regular, non-featured row", async () => {
+    // The tournament has ended, so the marquee frame + pulse is dropped while
+    // the host credit (a stacked subtitle) stays.
+    await renderWithFileRoutes(<></>)
+    const gauntlet = screen.getByRole("link", { name: /king's gauntlet/i })
+    expect(gauntlet).not.toHaveClass("crt-menu-row--featured")
+    expect(gauntlet).toHaveClass("crt-menu-row--stacked")
+  })
+
   it("orders The King's Gauntlet above Vagrant Story in the menu", async () => {
     await renderWithFileRoutes(<></>)
     const gauntlet = screen.getByRole("link", { name: /king's gauntlet/i })

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -47,7 +47,7 @@ export function HomePage() {
             >
               <li>
                 <a
-                  className="crt-menu-row crt-menu-row--active crt-menu-row--featured"
+                  className="crt-menu-row crt-menu-row--active crt-menu-row--stacked"
                   href="https://aoe2.criticalbit.gg/kings-gauntlet"
                 >
                   <span className="crt-menu-row__line">


### PR DESCRIPTION
## Summary

The King's Gauntlet tournament has ended, so its home-page menu entry no longer needs the marquee treatment. It now renders as a regular row alongside Vagrant Story — no surrounding frame, no pulse animation — while the **"Hosted by Hera"** credit stays as a stacked subtitle beneath the label. The link target (`/kings-gauntlet`) and `[WATCH]` tag are unchanged.

## CSS refactor

Split the bundled `.crt-menu-row--featured` rule along its two concerns so the featured treatment survives for reuse:

- **`.crt-menu-row--stacked`** (new) — layout only: column direction so `.crt-menu-row__line` carries the label while a `.crt-menu-subtitle` sits beneath it. This is what the de-featured Gauntlet row now uses.
- **`.crt-menu-row--featured`** (kept) — decoration only: the phosphor frame, tint, and `crt-featured-pulse`. Currently unused but retained for the next featured event; it composes with `--stacked` when an event also needs a subtitle.

## Tests

- Existing "credits Hera" and ordering specs pass unchanged.
- Added a guard asserting the Gauntlet row is `--stacked` and not `--featured`.

`pnpm lint`, `pnpm test:run`, and `pnpm build` all green.
