### PR TITLE
fix: satisfy react-hooks/set-state-in-effect in auth.tsx

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -109,6 +109,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // checkAuth handles its own errors internally; this .catch is a guard so a
     // future refactor can't leak an unhandled rejection (a bare `void` would
     // silence the floating-promise lint but not a real runtime rejection).
+    // checkAuth is async: its setState calls run after an await, not
+    // synchronously within the effect body, so cascading renders don't apply.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     checkAuth().catch((error: unknown) => captureException(error))
   }, [checkAuth])
 


### PR DESCRIPTION
eslint-plugin-react-hooks 7.1.x — arriving via #42 — adds `set-state-in-effect`, which errors on the mount-time auth check in `src/lib/auth.tsx`.

`checkAuth()` is async, so its setState calls run after an `await` rather than synchronously within the effect body; cascading renders don't apply. Disabled with that rationale, matching what `ag-tech-group/web-template` carries at the same call site.

Landing separately so a 35-package dependency update isn't blocked on a pre-existing code pattern. Until the bump lands the directive is unused — a **warning**, not an error — so CI stays green either way.

Verified: zero error-severity findings under 7.1.1; lint, test and build pass on the current 7.0.1 pin.